### PR TITLE
Fix: Center timeline cards on small screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,7 +130,7 @@
           </div>
 
           <!-- Content container -->
-          <div class="ml-10 md:ml-0 relative md:grid md:grid-cols-2 md:gap-8 items-start">
+          <div class="mx-auto md:ml-0 relative md:grid md:grid-cols-2 md:gap-8 items-start">
             <!-- Date -->
             <div class="hidden md:block md:text-right pr-8">
               <span
@@ -175,7 +175,7 @@
           </div>
 
           <!-- Content container -->
-          <div class="ml-10 md:ml-0 relative md:grid md:grid-cols-2 md:gap-8 items-start">
+          <div class="mx-auto md:ml-0 relative md:grid md:grid-cols-2 md:gap-8 items-start">
             <!-- Content (Left side in desktop) -->
             <div
               class="bg-white p-6 md:p-8 rounded-xl shadow-sm border border-apple-gray-200 hover:shadow-md transition-shadow duration-300 md:col-start-1">
@@ -222,7 +222,7 @@
           </div>
 
           <!-- Content container -->
-          <div class="ml-10 md:ml-0 relative md:grid md:grid-cols-2 md:gap-8 items-start">
+          <div class="mx-auto md:ml-0 relative md:grid md:grid-cols-2 md:gap-8 items-start">
             <!-- Date (Left side in desktop) -->
             <div class="hidden md:block md:text-right pr-8">
               <span
@@ -272,7 +272,7 @@
           </div>
 
           <!-- Content container -->
-          <div class="ml-10 md:ml-0 relative md:grid md:grid-cols-2 md:gap-8 items-start">
+          <div class="mx-auto md:ml-0 relative md:grid md:grid-cols-2 md:gap-8 items-start">
             <!-- Content (Left side in desktop) -->
             <div
               class="bg-white p-6 md:p-8 rounded-xl shadow-sm border border-apple-gray-200 hover:shadow-md transition-shadow duration-300 md:col-start-1">
@@ -319,7 +319,7 @@
           </div>
 
           <!-- Content container -->
-          <div class="ml-10 md:ml-0 relative md:grid md:grid-cols-2 md:gap-8 items-start">
+          <div class="mx-auto md:ml-0 relative md:grid md:grid-cols-2 md:gap-8 items-start">
             <!-- Date (Left side in desktop) -->
             <div class="hidden md:block md:text-right pr-8">
               <span


### PR DESCRIPTION
The timeline cards were previously shifted to the right on small screens due to a persistent left margin.

This commit addresses the issue by:
1. Removing the `ml-10` (margin-left) Tailwind class from the timeline item's content container in `index.html`.
2. Adding the `mx-auto` (margin-left: auto; margin-right: auto;) Tailwind class to the same container.

This change ensures that on small screens (where the timeline's vertical line and dots are hidden), the cards are now correctly centered. On medium and larger screens, the `md:ml-0` class continues to override `mx-auto`, maintaining the original alignment with the timeline's vertical line.