### PR TITLE
Fix: Hamburger menu requires two clicks after navigation

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -165,7 +165,12 @@ window.createMobileNavLink = function (container, links) {
       const mobileIconPath = document.getElementById('mobile-icon-path');
 
       if (mobileMenu && mobileIconPath) {
+        // Ensure menu is hidden using the class and style
+        mobileMenu.classList.add('hidden');
         mobileMenu.style.display = 'none';
+        // Remove animation classes to prevent conflicts
+        mobileMenu.classList.remove('animate-fade-in', 'animate-fade-out');
+        // Change back to hamburger icon
         mobileIconPath.setAttribute('d', 'M4 6h16M4 12h16M4 18h16');
       }
     });


### PR DESCRIPTION
The mobile hamburger menu was not reopening correctly after a navigation link was clicked. This was due to an inconsistency in how the menu's visibility state was managed.

When a navigation link was clicked, `style.display = 'none'` was set, but the `hidden` class (which the main menu toggle logic relies on) was not consistently applied. Additionally, animation classes were not always cleaned up, potentially interfering with subsequent interactions.

This commit modifies `createMobileNavLink` in `js/main.js` to:
- Add the `hidden` class to the mobile menu element when a nav link is clicked.
- Remove `animate-fade-in` and `animate-fade-out` classes to prevent animation conflicts.

This ensures that the menu state is consistent, allowing the menu to be reopened with a single click after navigation, as expected.